### PR TITLE
Update frontend.json

### DIFF
--- a/frontend.json
+++ b/frontend.json
@@ -1386,7 +1386,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(haproxy_server_current_sessions{host=\"$Host\"}) by (backend)",
+              "expr": "sum(haproxy_server_current_sessions{host=\"$Host\"}) by (backend)",
               "interval": "",
               "intervalFactor": 10,
               "legendFormat": "{{ backend }} ",


### PR DESCRIPTION
avg requests per server is a bit "weird" because we typically limit this and the impression of system usage is IMHO better visible by showing the sum of all active sessions for the backend at that time. this also allows showing different scaling effects when the number of backend servers changes.

BTW: I'm not sure why "metric" says "backend_current_queue" here.